### PR TITLE
some changes in services to make them more flexible

### DIFF
--- a/collectors/openbmpd/collector-cfg.yaml
+++ b/collectors/openbmpd/collector-cfg.yaml
@@ -125,7 +125,7 @@ data:
         #    For IPv6 use "[host or ip]:port".  Make sure to use double quotes for IPv6
         #    Can specify the protocol using <proto>://<host>[:port]
         brokers:
-        - broker.jalapeno.svc.cluster.local:9092
+        - broker.jalapeno:9092
         topics:
 
             # Global/System variables

--- a/collectors/openbmpd/collector.yaml
+++ b/collectors/openbmpd/collector.yaml
@@ -40,7 +40,7 @@ spec:
           protocol: TCP
         env:
         - name: KAFKA_FQDN
-          value: "broker.jalapeno.svc.cluster.local:9092"
+          value: "broker.jalapeno:9092"
         resources: {}
         volumeMounts:
             - name: configmap

--- a/destroy_jalapeno.sh
+++ b/destroy_jalapeno.sh
@@ -6,9 +6,9 @@ if [ -z "$1" ]
 fi
 
 echo "Shutting down Jalapeno"
+${KUBE} delete -f ${PWD}/infra/sa.yaml
 ${KUBE} delete namespace jalapeno
 ${KUBE} delete namespace jalapeno-collectors
-
 echo "Deleting Persistent Volumes"
 ${KUBE} delete pv arangodb
 ${KUBE} delete pv arangodb-apps

--- a/infra/kafka/1-zookeeper.yaml
+++ b/infra/kafka/1-zookeeper.yaml
@@ -14,7 +14,7 @@ spec:
     name: client
   selector:
     app: zookeeper
-    storage: persistent
+#    storage: persistent
 ---
 #apiVersion: v1
 #kind: Service

--- a/infra/kafka/2-broker-cfg.yaml
+++ b/infra/kafka/2-broker-cfg.yaml
@@ -163,7 +163,7 @@ data:
     # server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
     # You can also append an optional chroot string to the urls to specify the
     # root directory for all kafka znodes.
-    zookeeper.connect=zookeeper-np:2181
+    zookeeper.connect=zookeeper:2181
 
     # Timeout in ms for connecting to zookeeper
     #zookeeper.connection.timeout.ms=6000

--- a/infra/kafka/3-kafka.yaml
+++ b/infra/kafka/3-kafka.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
     ports:
       - port: 9092
-    # [podname].broker.kafka.svc.cluster.local
+    # [podname].broker.kafka
     clusterIP: None
     selector:
       app: kafka

--- a/infra/pipeline-egress/pipeline_egress_cfg.yaml
+++ b/infra/pipeline-egress/pipeline_egress_cfg.yaml
@@ -1158,7 +1158,7 @@ data:
 
     stage=xport_input
 
-    brokers=kafka-0.broker.jalapeno.svc.cluster.local:9092
+    brokers=kafka-0.broker.jalapeno:9092
 
     encoding=gpb
 
@@ -1171,7 +1171,7 @@ data:
 
     type=metrics
 
-    influx=http://influxdb-0.influxdb.jalapeno.svc.cluster.local:8086
+    influx=http://influxdb-0.influxdb.jalapeno:8086
 
     datachanneldepth=1000
 

--- a/infra/templates/kafka/kafka_ss_template.yaml
+++ b/infra/templates/kafka/kafka_ss_template.yaml
@@ -38,11 +38,11 @@ spec:
         - ./bin/kafka-server-start.sh
         - /etc/kafka/server.properties
         - --override
-        - listeners=PLAINTEXT://kafka-0.broker.jalapeno.svc.cluster.local:9092
+        - listeners=PLAINTEXT://kafka-0.broker.jalapeno:9092
         - --override
         - advertised.listeners=PLAINTEXT://{{ kafka_endpoint }}
         - --override
-        -   zookeeper.connect=zookeeper.jalapeno.svc.cluster.local:2181
+        -   zookeeper.connect=zookeeper.jalapeno:2181
         - --override
         -   log.retention.hours=1
         - --override

--- a/services/processors/topology/topology_dp.yaml
+++ b/services/processors/topology/topology_dp.yaml
@@ -21,7 +21,7 @@ spec:
         args:
           - topology
           - --arango-url
-          - http://arango-np.jalapeno.svc:8529
+          - http://arango-np.jalapeno:8529
           - --arango-user
           - root
           - --arango-password
@@ -33,7 +33,7 @@ spec:
           - --kafka-topics
           - "openbmp.parsed.router,openbmp.parsed.peer,openbmp.parsed.unicast_prefix,openbmp.parsed.ls_link,openbmp.parsed.ls_node,openbmp.parsed.ls_prefix,openbmp.parsed.l3vpn,openbmp.parsed.evpn"
           - --kafka-brokers
-          - broker.jalapeno.svc:9092
+          - broker.jalapeno:9092
           - --asn
           - "100000"
           - --transit-provider-asns

--- a/services/templates/collectors/topology_dp_template.yaml
+++ b/services/templates/collectors/topology_dp_template.yaml
@@ -21,7 +21,7 @@ spec:
         args:
           - topology
           - --arango-url
-          - http://arangodb.jalapeno.svc.cluster.local:8529
+          - http://arangodb.jalapeno:8529
           - --arango-user
           - root
           - --arango-password


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Currently all the configuration is hard coded for a default cluster domain name cluster.local. Not all clusters, especially in production use it. This change will make Jalapeno more friendly for a non default cluster's domain name.